### PR TITLE
Fix: 그리드 뷰 카드 높이 일정하지 않은 현상 수정

### DIFF
--- a/next-app/src/components/common/FeedItem/GridType.style.tsx
+++ b/next-app/src/components/common/FeedItem/GridType.style.tsx
@@ -6,6 +6,7 @@ export const Container = styled.div`
   overflow: hidden;
   border-radius: 20px;
   background-color: ${colors.gray100};
+  height: 290px;
 `
 
 export const GridTypeWrapper = styled.div<{ imageUrl?: string }>`
@@ -14,7 +15,8 @@ export const GridTypeWrapper = styled.div<{ imageUrl?: string }>`
     css`
       height: 100%;
     `};
-  padding: 20px;
+    
+  padding: ${({ imageUrl }) => (imageUrl ? ' 12px 20px 20px 20px' : '20px')};
   display: flex;
   justify-content: space-between;
   flex-direction: column;
@@ -26,11 +28,12 @@ export const Title = styled.h2<{ isImageExist: boolean }>`
   ${({ isImageExist }) => ellipsis(isImageExist ? 2 : 3)}
 
   color: ${colors.gray800};
+  min-height: ${({ isImageExist }) => isImageExist && '52px'};
 `
 
 export const Description = styled.div`
   ${getTypographyStyles('Body1_M')}
-  ${ellipsis(5)}
+  ${ellipsis(7)}
   
   color: ${colors.gray600};
   word-break: break-all;

--- a/next-app/src/components/common/FeedItem/GridType.tsx
+++ b/next-app/src/components/common/FeedItem/GridType.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import Icons from 'assets/icons'
 import { colors } from 'styles/colors'
 import type { Item } from 'types/feeds'
@@ -23,7 +24,7 @@ interface Props {
 
 const GridType = ({ item }: Props) => {
   const { handleRead, handleLike } = useToggleLike(item)
-
+ 
   return (
     <Container>
       {item.imageUrl && (
@@ -45,7 +46,11 @@ const GridType = ({ item }: Props) => {
         </div>
       )}
       <GridTypeWrapper imageUrl={item.imageUrl}>
-        <Flex gap={8} direction="column">
+        <Flex
+          gap={8}
+          direction="column"
+          style={{ height: !!item.imageUrl ? 'auto' : '206px' }}
+        >
           <S.Body>
             <Anchor
               href={item.link}


### PR DESCRIPTION
## Motivation 🤔

- 그리드 뷰 일때, 썸네일이나 제목 줄 수에 따라 카드높이 일정하지 않은 현상 수정

<br>

## Key Changes 🔑

<img width="701" alt="스크린샷 2022-11-04 오전 1 29 08" src="https://user-images.githubusercontent.com/67362026/199778346-21062ca8-5f32-403a-9fec-da1a1b83c475.png">


<br>

## To Reviews 🙏🏻

-
