### PR TITLE
fix: ssr 시 호출하는 유저 정보 api 인스턴스 서버측 전용으로 주입

### DIFF
--- a/next-app/src/pages/index.tsx
+++ b/next-app/src/pages/index.tsx
@@ -5,7 +5,7 @@ import { parseCookies } from 'nookies'
 
 import RssInputView from 'components/views/RssInput'
 import FeedsContainerView from 'components/views/Feeds/FeedsContainer'
-import { getUserInfo, UserProfile } from 'services/auth'
+import { getUserInfo, getUserInfoServerSide, UserProfile } from 'services/auth'
 import { CACHE_KEYS } from 'services/cacheKeys'
 import { AccessToken } from 'constants/auth'
 import { createApi } from 'services/api'
@@ -37,7 +37,10 @@ export const getServerSideProps = async (context: GetServerSideProps) => {
     ] = `Bearer ${cookies[AccessToken]}`
 
     const queryClient = new QueryClient()
-    await queryClient.prefetchQuery<UserProfile>(CACHE_KEYS.me, getUserInfo)
+    await queryClient.prefetchQuery<UserProfile>(
+      CACHE_KEYS.me,
+      getUserInfoServerSide(api)
+    )
     await queryClient.prefetchInfiniteQuery(
       CACHE_KEYS.feeds,
       ({ pageParam = 1 }) => getFeedsServerSide(api)(pageParam)

--- a/next-app/src/services/auth/index.ts
+++ b/next-app/src/services/auth/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosResponse } from 'axios'
+import axios, { type AxiosError, AxiosInstance, AxiosResponse } from 'axios'
 import Cookies from 'js-cookie'
 
 import { getApiEndpoint } from 'envs'
@@ -24,6 +24,10 @@ export const submitAccessToken = (token: string) => {
 
 export const getUserInfo = () => {
   return api.get<null, UserProfile>(`/users/me`)
+}
+
+export const getUserInfoServerSide = (_api: AxiosInstance) => () => {
+  return _api.get<null, UserProfile>(`/users/me`)
 }
 
 export const refreshAccessToken = async (axiosError: AxiosError) => {


### PR DESCRIPTION
## Motivation 🤔

- 서버 사이드 렌더링 시 유저 정보 api 호출할 때 서버 전용 인스턴스 사용하도록 변경

<br>

## Key Changes 🔑

-

<br>

## To Reviews 🙏🏻

-
