### PR TITLE
fix : 로그인 하지 않은 상태에서 getUserInfo 실행 제어

### DIFF
--- a/next-app/src/components/common/Layout/Nav/TopNavBar/TopNavBar.tsx
+++ b/next-app/src/components/common/Layout/Nav/TopNavBar/TopNavBar.tsx
@@ -12,8 +12,6 @@ import * as S from './TopNavBar.style'
 
 import Icons from 'assets/icons'
 
-const accessToken = Cookies.get(AccessToken)
-
 interface Props {
   setShowSideBar: Dispatch<SetStateAction<boolean | null>>
 }
@@ -23,6 +21,7 @@ const TopNavBar = forwardRef<HTMLDivElement, Props>(function TopNavBar(
   ref
 ) {
   const router = useRouter()
+  const accessToken = Cookies.get(AccessToken)
 
   const { data: userProfile } = useQuery<UserProfile>(
     CACHE_KEYS.me,

--- a/next-app/src/components/common/Layout/Nav/TopNavBar/TopNavBar.tsx
+++ b/next-app/src/components/common/Layout/Nav/TopNavBar/TopNavBar.tsx
@@ -2,13 +2,17 @@ import React, { forwardRef, type Dispatch, type SetStateAction } from 'react'
 import Image from 'next/legacy/image'
 import { useRouter } from 'next/router'
 import { useQuery } from '@tanstack/react-query'
+import Cookies from 'js-cookie'
 
 import { getUserInfo, type UserProfile } from 'services/auth'
+import { AccessToken, RefreshToken } from 'constants/auth'
 import { CACHE_KEYS } from 'services/cacheKeys'
 
 import * as S from './TopNavBar.style'
 
 import Icons from 'assets/icons'
+
+const accessToken = Cookies.get(AccessToken)
 
 interface Props {
   setShowSideBar: Dispatch<SetStateAction<boolean | null>>
@@ -19,10 +23,13 @@ const TopNavBar = forwardRef<HTMLDivElement, Props>(function TopNavBar(
   ref
 ) {
   const router = useRouter()
+
   const { data: userProfile } = useQuery<UserProfile>(
     CACHE_KEYS.me,
-    getUserInfo
+    getUserInfo,
+    { enabled: !!accessToken }
   )
+
   const name = userProfile?.name
   const profileImageUrl = userProfile?.profileImageUrl
   return (


### PR DESCRIPTION
## Motivation 🤔
- 로그인 하지 않은 상태에서 getUserInfo를 계속 실행하기 때문에, 팝업창이 계속 노출
![스크린샷 2022-12-11 오후 2 12 34](https://user-images.githubusercontent.com/65284962/206888589-6c998662-2cb1-4e22-8eb8-f46fa286512a.png)

<br>

## Key Changes 🔑

- accessToken을 통해 해당 api의 react-query를 제어: ` { enabled: !!accessToken }`

<br>

## To Reviews 🙏🏻

-
