### PR TITLE
fix : 로그아웃 시, 메뉴 내용클릭 시 로그인 페이지로 이동

### DIFF
--- a/next-app/src/components/common/Layout/Nav/SideNavBar/SideMenuBar.tsx
+++ b/next-app/src/components/common/Layout/Nav/SideNavBar/SideMenuBar.tsx
@@ -17,8 +17,6 @@ import * as S from './SideMenuBar.style'
 
 import Icons from 'assets/icons'
 
-const accessToken = Cookies.get(AccessToken)
-
 interface Props {
   setShowSideBar: Dispatch<SetStateAction<boolean | null>>
   isOpen: boolean | null
@@ -55,13 +53,25 @@ const SideMenuBar = forwardRef<HTMLDivElement, Props>(function SideMenuBar(
       </S.CloseSection>
       <S.MenuSection>
         <div>
-          <Anchor onClick={() => movePage('/mypage/channels')}>
-            <MenuItem title="내가 등록한 채널" iconUrl={Icons.Folder} />
-          </Anchor>
+          <Link
+            href={accessToken ? '/mypage/channels' : '/signup'}
+            passHref
+            legacyBehavior
+          >
+            <Anchor onClick={() => setShowSideBar(false)}>
+              <MenuItem title="내가 등록한 채널" iconUrl={Icons.Folder} />
+            </Anchor>
+          </Link>
 
-          <Anchor onClick={() => movePage('/mypage/posts')}>
-            <MenuItem title="내가 저장한 게시물" iconUrl={Icons.Star} />
-          </Anchor>
+          <Link
+            href={accessToken ? '/mypage/posts' : '/signup'}
+            passHref
+            legacyBehavior
+          >
+            <Anchor onClick={() => setShowSideBar(false)}>
+              <MenuItem title="내가 저장한 게시물" iconUrl={Icons.Star} />
+            </Anchor>
+          </Link>
         </div>
         <div>
           <Anchor

--- a/next-app/src/components/common/Layout/Nav/SideNavBar/SideMenuBar.tsx
+++ b/next-app/src/components/common/Layout/Nav/SideNavBar/SideMenuBar.tsx
@@ -29,6 +29,7 @@ const SideMenuBar = forwardRef<HTMLDivElement, Props>(function SideMenuBar(
   ref
 ) {
   const router = useRouter()
+  const accessToken = Cookies.get(AccessToken)
 
   const movePage = (href: string) => {
     router.push(accessToken ? href : '/signup')

--- a/next-app/src/components/common/Layout/Nav/SideNavBar/SideMenuBar.tsx
+++ b/next-app/src/components/common/Layout/Nav/SideNavBar/SideMenuBar.tsx
@@ -7,13 +7,17 @@ import React, {
 import Image from 'next/legacy/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import Cookies from 'js-cookie'
 
 import MenuItem from './MenuItem'
 import Anchor from 'components/common/Anchor'
+import { AccessToken } from 'constants/auth'
 
 import * as S from './SideMenuBar.style'
 
 import Icons from 'assets/icons'
+
+const accessToken = Cookies.get(AccessToken)
 
 interface Props {
   setShowSideBar: Dispatch<SetStateAction<boolean | null>>
@@ -24,7 +28,12 @@ const SideMenuBar = forwardRef<HTMLDivElement, Props>(function SideMenuBar(
   { setShowSideBar, isOpen }: Props,
   ref
 ) {
-  const { pathname } = useRouter()
+  const router = useRouter()
+
+  const movePage = (href: string) => {
+    router.push(accessToken ? href : '/signup')
+    setShowSideBar(false)
+  }
 
   useEffect(() => {
     setShowSideBar((prev) => {
@@ -33,7 +42,7 @@ const SideMenuBar = forwardRef<HTMLDivElement, Props>(function SideMenuBar(
       }
       return prev
     })
-  }, [pathname, setShowSideBar])
+  }, [router.pathname, setShowSideBar])
 
   return (
     <S.SideMenuBarContainer isOpen={isOpen} ref={ref}>
@@ -45,16 +54,13 @@ const SideMenuBar = forwardRef<HTMLDivElement, Props>(function SideMenuBar(
       </S.CloseSection>
       <S.MenuSection>
         <div>
-          <Link href="/mypage/channels" passHref legacyBehavior>
-            <Anchor onClick={() => setShowSideBar(false)}>
-              <MenuItem title="내가 등록한 채널" iconUrl={Icons.Folder} />
-            </Anchor>
-          </Link>
-          <Link href="/mypage/posts" passHref legacyBehavior>
-            <Anchor onClick={() => setShowSideBar(false)}>
-              <MenuItem title="내가 저장한 게시물" iconUrl={Icons.Star} />
-            </Anchor>
-          </Link>
+          <Anchor onClick={() => movePage('/mypage/channels')}>
+            <MenuItem title="내가 등록한 채널" iconUrl={Icons.Folder} />
+          </Anchor>
+
+          <Anchor onClick={() => movePage('/mypage/posts')}>
+            <MenuItem title="내가 저장한 게시물" iconUrl={Icons.Star} />
+          </Anchor>
         </div>
         <div>
           <Anchor


### PR DESCRIPTION
## Motivation 🤔
- 로그아웃 시, 메뉴 내용클릭 시 로그인 페이지로 이동
![스크린샷 2022-12-11 오후 3 09 41](https://user-images.githubusercontent.com/65284962/206889918-766d300f-a179-4413-aad2-74e79e7b680c.png)


<br>

## Key Changes 🔑
- accessToken을 통해 시작페이지 / 클릭 한 메뉴 페이지로 이동 변경

<br>

## To Reviews 🙏🏻

-
