### PR TITLE
Feat: 모바일 환경에서 주소창 minimalized 되도록 스타일 변경

### DIFF
--- a/next-app/src/components/common/Layout/Layout.style.tsx
+++ b/next-app/src/components/common/Layout/Layout.style.tsx
@@ -1,7 +1,12 @@
 import styled, { css } from 'styled-components'
 
 export const Container = styled.div<{ fullHeight: boolean }>`
-  padding-top: 75px;
+  /* border: 1px solid red; */
+  /* padding-top: 75px; */
+
+  /* background-color: pink; */
+  /* height: 2000px; */
+  /* height: calc(100vh - 75px); */
 
   ${({ fullHeight }) =>
     fullHeight &&
@@ -9,7 +14,16 @@ export const Container = styled.div<{ fullHeight: boolean }>`
       padding-top: 0;
 
       main {
-        height: 100dvh;
+        min-height: 100dvh;
+        background-color: green;
+        /* height: 100vh; */
+        /* height: 100%; */
       }
     `};
+`
+
+export const TestContainer = styled.div`
+  min-height: calc(100vh - 81px);
+  padding-top: 75px; // Nav 높이 만큼
+
 `

--- a/next-app/src/components/common/Layout/Layout.style.tsx
+++ b/next-app/src/components/common/Layout/Layout.style.tsx
@@ -19,7 +19,6 @@ import styled, { css } from 'styled-components'
 //     `};
 // `
 
-
 export const Container = styled.main<{ fullHeight: boolean }>`
   min-height: calc(100dvh - 75px);
   padding-top: 75px; // Nav 높이 만큼
@@ -27,15 +26,8 @@ export const Container = styled.main<{ fullHeight: boolean }>`
   ${({ fullHeight }) =>
     fullHeight &&
     css`
-      min-height: 100dvh
-      padding-top: 0;
-
-      main {
-        min-height: 100dvh;
-        background-color: green;
-        /* height: 100vh; */
-        /* height: 100%; */
-      }
+      min-height: 100dvh;
+      padding-top: 0px;
     `};
 `
 

--- a/next-app/src/components/common/Layout/Layout.style.tsx
+++ b/next-app/src/components/common/Layout/Layout.style.tsx
@@ -1,16 +1,33 @@
 import styled, { css } from 'styled-components'
 
-export const Container = styled.div<{ fullHeight: boolean }>`
-  /* border: 1px solid red; */
-  /* padding-top: 75px; */
+// export const Container = styled.div<{ fullHeight: boolean }>`
+//   min-height: calc(100dvh - 75px);
+//   padding-top: 75px; // Nav 높이 만큼
 
-  /* background-color: pink; */
-  /* height: 2000px; */
-  /* height: calc(100vh - 75px); */
+//   ${({ fullHeight }) =>
+//     fullHeight &&
+//     css`
+//       min-height: 100dvh
+//       padding-top: 0;
+
+//       main {
+//         min-height: 100dvh;
+//         background-color: green;
+//         /* height: 100vh; */
+//         /* height: 100%; */
+//       }
+//     `};
+// `
+
+
+export const Container = styled.main<{ fullHeight: boolean }>`
+  min-height: calc(100dvh - 75px);
+  padding-top: 75px; // Nav 높이 만큼
 
   ${({ fullHeight }) =>
     fullHeight &&
     css`
+      min-height: 100dvh
       padding-top: 0;
 
       main {
@@ -25,5 +42,4 @@ export const Container = styled.div<{ fullHeight: boolean }>`
 export const TestContainer = styled.div`
   min-height: calc(100vh - 81px);
   padding-top: 75px; // Nav 높이 만큼
-
 `

--- a/next-app/src/components/common/Layout/Layout.style.tsx
+++ b/next-app/src/components/common/Layout/Layout.style.tsx
@@ -1,24 +1,5 @@
 import styled, { css } from 'styled-components'
 
-// export const Container = styled.div<{ fullHeight: boolean }>`
-//   min-height: calc(100dvh - 75px);
-//   padding-top: 75px; // Nav 높이 만큼
-
-//   ${({ fullHeight }) =>
-//     fullHeight &&
-//     css`
-//       min-height: 100dvh
-//       padding-top: 0;
-
-//       main {
-//         min-height: 100dvh;
-//         background-color: green;
-//         /* height: 100vh; */
-//         /* height: 100%; */
-//       }
-//     `};
-// `
-
 export const Container = styled.main<{ fullHeight: boolean }>`
   min-height: calc(100dvh - 75px);
   padding-top: 75px; // Nav 높이 만큼
@@ -29,9 +10,4 @@ export const Container = styled.main<{ fullHeight: boolean }>`
       min-height: 100dvh;
       padding-top: 0px;
     `};
-`
-
-export const TestContainer = styled.div`
-  min-height: calc(100vh - 81px);
-  padding-top: 75px; // Nav 높이 만큼
 `

--- a/next-app/src/components/common/Layout/Layout.tsx
+++ b/next-app/src/components/common/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import Nav from './Nav'
 import { ROUTE } from 'constants/route'
 
-import { Container } from './Layout.style'
+import { Container, TestContainer } from './Layout.style'
 
 interface Props {
   children: React.ReactNode
@@ -17,9 +17,16 @@ const Layout = ({ children }: Props) => {
 
   return (
     <>
-      {hasGNB && <Nav />}
+      {/* {hasGNB && <Nav />}
       <Container fullHeight={!hasGNB}>
         <main>{children}</main>
+      </Container> */}
+
+      {hasGNB && <Nav />}
+      <Container fullHeight={!hasGNB}>
+        <TestContainer>
+          <main>{children}</main>
+        </TestContainer>
       </Container>
     </>
   )

--- a/next-app/src/components/common/Layout/Layout.tsx
+++ b/next-app/src/components/common/Layout/Layout.tsx
@@ -24,9 +24,10 @@ const Layout = ({ children }: Props) => {
 
       {hasGNB && <Nav />}
       <Container fullHeight={!hasGNB}>
-        <TestContainer>
+        {children}
+        {/* <TestContainer>
           <main>{children}</main>
-        </TestContainer>
+        </TestContainer> */}
       </Container>
     </>
   )

--- a/next-app/src/components/common/Layout/Layout.tsx
+++ b/next-app/src/components/common/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import Nav from './Nav'
 import { ROUTE } from 'constants/route'
 
-import { Container, TestContainer } from './Layout.style'
+import { Container } from './Layout.style'
 
 interface Props {
   children: React.ReactNode
@@ -17,18 +17,8 @@ const Layout = ({ children }: Props) => {
 
   return (
     <>
-      {/* {hasGNB && <Nav />}
-      <Container fullHeight={!hasGNB}>
-        <main>{children}</main>
-      </Container> */}
-
       {hasGNB && <Nav />}
-      <Container fullHeight={!hasGNB}>
-        {children}
-        {/* <TestContainer>
-          <main>{children}</main>
-        </TestContainer> */}
-      </Container>
+      <Container fullHeight={!hasGNB}>{children}</Container>
     </>
   )
 }

--- a/next-app/src/components/common/PageContainer/index.tsx
+++ b/next-app/src/components/common/PageContainer/index.tsx
@@ -20,9 +20,8 @@ const Container = styled.div<{
   backgroundColor?: string
 }>`
   width: 100%;
-  height: 100%;
-  overflow: auto;
-  padding: ${({ padding }) => padding || '60px 0 80px'};
+  min-height: calc(100dvh - 75px);
+  padding: ${({ padding }) => padding || '60px 0 40px'};
   background-color: ${({ backgroundColor }) =>
     backgroundColor || colors.mainBG};
 `

--- a/next-app/src/components/views/Feeds/FeedsContainer.style.tsx
+++ b/next-app/src/components/views/Feeds/FeedsContainer.style.tsx
@@ -5,8 +5,9 @@ import { mediaQuery } from 'styles/mediaQuery'
 
 export const Container = styled.div`
   display: flex;
-  flex-direction: column;
   align-items: center;
+  flex-direction: column;
+  min-height: calc(100dvh - 203px);
   background-color: ${colors.mainBG};
 `
 

--- a/next-app/src/components/views/Feeds/FeedsContainer.style.tsx
+++ b/next-app/src/components/views/Feeds/FeedsContainer.style.tsx
@@ -12,7 +12,7 @@ export const Container = styled.div`
 `
 
 export const FeedWrapper = styled.div`
-  margin: 40px 20px;
+  margin: 40px 20px 60px;
   padding: 0 12px;
   max-width: 650px;
   width: 100%;

--- a/next-app/src/components/views/Introduce/Introduce.style.tsx
+++ b/next-app/src/components/views/Introduce/Introduce.style.tsx
@@ -4,15 +4,14 @@ import { colors } from 'styles/colors'
 import { mediaQuery } from 'styles/mediaQuery'
 
 export const Wrapper = styled.div`
-  margin: 100px 0;
-
+  padding: 100px 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 100px;
 
   ${mediaQuery.tablet`
-    margin: 40px 20px;
+    padding: 40px 20px;
   `}
 `
 export const Container = styled.div`

--- a/next-app/src/pages/[userName].tsx
+++ b/next-app/src/pages/[userName].tsx
@@ -1,9 +1,9 @@
 import type { NextPage } from 'next'
 
-import UserPagePageContainer from 'components/views/UserPage'
+import UserPageContainer from 'components/views/UserPage'
 
 const UserProfile: NextPage = () => {
-  return <UserPagePageContainer />
+  return <UserPageContainer />
 }
 
 export default UserProfile

--- a/next-app/src/pages/_app.tsx
+++ b/next-app/src/pages/_app.tsx
@@ -19,7 +19,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Head>
         <meta
           name="viewport"
-          content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1, viewport-fit=cover, minimal-ui"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1, viewport-fit=cover"
           key="viewport"
         />
         <meta

--- a/next-app/src/pages/_app.tsx
+++ b/next-app/src/pages/_app.tsx
@@ -17,6 +17,11 @@ function MyApp({ Component, pageProps }: AppProps) {
     <>
       <Head>
         <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1, viewport-fit=cover, minimal-ui"
+          key="viewport"
+        />
+        <meta
           name="description"
           content="여기저기 둥둥 떠있는 나의 인사이트 컨텐츠들을 피둥에서 모아보기! 크롬 새 탭에서 바로 시작하세요!"
         />

--- a/next-app/src/pages/_app.tsx
+++ b/next-app/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import { useGoogleAnalytics as GoogleAnalytics } from 'utils/hooks'
 
 import 'styles/reset.css'
 import 'styles/font.css'
+import 'styles/global.css'
 import 'react-loading-skeleton/dist/skeleton.css'
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/next-app/src/styles/global.css
+++ b/next-app/src/styles/global.css
@@ -1,0 +1,21 @@
+* {
+  -webkit-tap-highlight-color: transparent;
+  font-family: 'Pretendard', 'sans-serif';
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+*::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera*/
+}
+
+
+html {
+  height: -webkit-fill-available;
+}
+
+body {
+  overflow: unset;
+  /* mobile viewport bug fix */
+  min-height: -webkit-fill-available;
+}

--- a/next-app/src/styles/reset.css
+++ b/next-app/src/styles/reset.css
@@ -107,16 +107,12 @@ section {
   display: block;
 }
 html, body {
-  overflow: scroll;
-  /* height: 100%; */
-  /* overflow: hidden; */
+
 }
 body {
   line-height: 1;
 }
 main {
-  /* height: calc(100dvh - 75px);
-  overflow: auto; */
 }
 ol,
 ul {

--- a/next-app/src/styles/reset.css
+++ b/next-app/src/styles/reset.css
@@ -106,17 +106,17 @@ nav,
 section {
   display: block;
 }
-html,
-body {
-  height: 100%;
-  overflow: hidden;
+html, body {
+  overflow: scroll;
+  /* height: 100%; */
+  /* overflow: hidden; */
 }
 body {
   line-height: 1;
 }
 main {
-  height: calc(100dvh - 75px);
-  overflow: auto;
+  /* height: calc(100dvh - 75px);
+  overflow: auto; */
 }
 ol,
 ul {


### PR DESCRIPTION
## Motivation 🤔

- 모바일 웹뷰에서 스크롤시에 주소창 minimalized 되도록 개선

<br>

## Key Changes 🔑

**AS-IS**
https://user-images.githubusercontent.com/67362026/228766486-bfb5ed24-a819-4cfa-9701-2c5a6605bc1f.MP4

**TO-BE**
https://user-images.githubusercontent.com/67362026/228766609-1ff2e779-aec7-4998-b338-e36bca269700.MP4

- 상위태그에 불필요하게 적용된 height나 overflow 속성 제거
- meta tag에 viewport 속성 추가

<img width="1506" alt="스크린샷 2023-03-30 오후 4 02 47" src="https://user-images.githubusercontent.com/67362026/228767298-5b2bd976-04fa-49cf-953f-d49c3ccc381f.png">

- 등록한 채널 없을 경우, 내 피드에서 배경색 꽉 채워지지 않는 현상 개선
- 기타 페이지 하단 padding 조절 등

<br>

## To Reviews 🙏🏻

-
