### PR TITLE
fix: react query 전역 캐시 렌더링 로직 안쪽으로 넣어 ssr 세션 겹침 문제 해결

### DIFF
--- a/next-app/src/components/common/Providers/index.tsx
+++ b/next-app/src/components/common/Providers/index.tsx
@@ -4,6 +4,7 @@ import {
   QueryClient,
 } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { useState } from 'react'
 
 import { globalQueryErrorHandler } from 'features/errors/globalQueryErrorHandler'
 
@@ -12,19 +13,23 @@ interface Props {
   pageProps: any
 }
 
-const queryClient: QueryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retryOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-
-      onError: (err: unknown) => globalQueryErrorHandler(err, queryClient),
-    },
-  },
-})
-
 const Providers = ({ pageProps, children }: Props) => {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retryOnMount: false,
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+
+            onError: (err: unknown) =>
+              globalQueryErrorHandler(err, queryClient),
+          },
+        },
+      })
+  )
+
   return (
     <QueryClientProvider client={queryClient}>
       <Hydrate state={pageProps.dehydratedState}>{children}</Hydrate>


### PR DESCRIPTION
## Motivation 🤔

- SSR 과정에서 CACHE_KEY.me 에 대한 결과물이 프론트 서버 캐시에 남아 [로그아웃 > 새로고침] 했을 때 SSR 결과물이 특정 유저의 정보를 담은 채 첫 렌더링이 되는 문제

<br>

## Key Changes 🔑

- 쿼리 캐시를 렌더링 로직 안쪽으로 넣어 초기화 함

<br>

## To Reviews 🙏🏻

-
