### PR TITLE
fix: useSubscribeChannel에 에러 핸들링 추가

### DIFF
--- a/apps/next-app/src/features/channel/index.ts
+++ b/apps/next-app/src/features/channel/index.ts
@@ -19,6 +19,9 @@ export const useSubscribeChannel = () => {
       ChannelToast.addChannel()
       client.invalidateQueries(CACHE_KEYS.recommended(['channels']))
     },
+    onError: (err: AxiosError<ErrorBody, any>) => {
+      ChannelToast.failAddChannel(getAxiosError(err).message)
+    },
   })
 }
 


### PR DESCRIPTION
## Motivation 🤔
- 안녕하세요! 피둥을 사용하다가 다른 사용자가 등록한 채널을 추가하려고 버튼을 눌렀는데 반응이 없어 네트워크 탭을 열어보니 이미 구독한 채널이여서 400 에러가 발생했더라구요.
- 에러 상황에 대한 알럿이 있는 것이 좋을 것 같아 코드를 살펴봤는데, 이전에는 에러 핸들링이 있었으나 코드를 수정하시다가 에러 처리가 누락된 것 같아 추가하여 PR 올려봅니다 🙂

<br>

## Key Changes 🔑

- useSubscribeChannel 함수가 반환하는 useMutation 함수에 onError를 추가하였습니다.

<br>

## To Reviews 🙏🏻

-
